### PR TITLE
make validator functions serializable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ target/
 *.swp
 *.swo
 
+test.sqlite3

--- a/gtin_fields/fields.py
+++ b/gtin_fields/fields.py
@@ -16,7 +16,7 @@ class ProductCodeFieldBase(CharField):
                 verbose_name=self._primary_validator.verbose_object_name,
                 validators=kwargs.get(
                     'validators', []
-                ) + [self._primary_validator.validate],
+                ) + [self._primary_validator],
             ),
             **kwargs
         )
@@ -27,7 +27,7 @@ class ProductCodeFieldBase(CharField):
             dict(
                 max_length=max(self._primary_validator.valid_lengths),
                 min_length=min(self._primary_validator.valid_lengths),
-                validators=[self._primary_validator.validate],
+                validators=[self._primary_validator],
             ),
             **kwargs
         )

--- a/gtin_fields/validators.py
+++ b/gtin_fields/validators.py
@@ -22,11 +22,13 @@ for use (see .fields for usage):
 import re
 
 from django.core.exceptions import ValidationError
+from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy
 from gtin_fields import gtin
 from stdnum import isbn
 
 
+@deconstructible
 class AlphaNumCodeValidatorBase:
     """ A generic product code validator.
 
@@ -70,6 +72,7 @@ class AlphaNumCodeValidatorBase:
         )
 
 
+@deconstructible
 class _ASINValidator(AlphaNumCodeValidatorBase):
     """ ASIN (Amazon Standard Identification Number) validator.
 
@@ -97,6 +100,7 @@ class _ASINValidator(AlphaNumCodeValidatorBase):
         super().__init__(*args, **kwargs)
 
 
+@deconstructible
 class GTINValidatorBase(AlphaNumCodeValidatorBase):
     """ Validation base for common GTIN codes.
 
@@ -126,6 +130,7 @@ class GTINValidatorBase(AlphaNumCodeValidatorBase):
             self.invalid(value, 'Failed checksum')
 
 
+@deconstructible
 class _ISBNValidator(GTINValidatorBase):
     """ Check string is a well-formed ISBN number"""
     verbose_object_name = "ISBN"
@@ -133,6 +138,7 @@ class _ISBNValidator(GTINValidatorBase):
     is_valid_checksum = staticmethod(isbn.is_valid)
 
 
+@deconstructible
 class _UPCAValidator(GTINValidatorBase):
     """ Check string is a well-formed GTIN-12 / UPC-A code. """
     verbose_object_name = "UPC-A"
@@ -140,6 +146,7 @@ class _UPCAValidator(GTINValidatorBase):
     is_valid_checksum = staticmethod(gtin.is_valid)
 
 
+@deconstructible
 class _EAN13Validator(GTINValidatorBase):
     """ Check string is a well-formed GTIN-13 / EAN-13 code. """
     verbose_object_name = "EAN-13"
@@ -147,6 +154,7 @@ class _EAN13Validator(GTINValidatorBase):
     is_valid_checksum = staticmethod(gtin.is_valid)
 
 
+@deconstructible
 class _GTIN14Validator(GTINValidatorBase):
     """ Check string is a well-formed GTIN-14 code. """
     verbose_object_name = "GTIN-14"

--- a/gtin_fields/validators.py
+++ b/gtin_fields/validators.py
@@ -1,23 +1,14 @@
 """ Provides validation for common GTIN fields.
 
-Available validators (ready for use as a django validator which is a function):
+Available validator instances (ready for use as a django validator which is
+any callable):
 
-    ISBNValidatorFunc (ISBN)
-    UPCAValidatorFunc (UPC-A / GTIN-12)
-    EANValidatorFunc (EAN-13 / GTIN-13)
-    GTIN14ValidatorFunc (GTIN-14)
-    ASINValidatorFunc (Amazon Standard Identification Number, possible values)
-    ASINStrictValidatorFunc (ASIN limiting to currently known patterns)
-
-If access to validator attributes is needed then these instances are available
-for use (see .fields for usage):
-
-    ISBNValidator = _ISBNValidator()
-    UPCAValidator = _UPCAValidator()
-    EAN13Validator = _EAN13Validator()
-    GTIN14Validator = _GTIN14Validator()
-    ASINValidator = _ASINValidator()
-    ASINStrictValidator = _ASINValidator(strict=True)
+    ISBNValidator (ISBN)
+    UPCAValidator (UPC-A / GTIN-12)
+    EANValidator (EAN-13 / GTIN-13)
+    GTIN14Validator (GTIN-14)
+    ASINValidator (Amazon Standard Identification Number, possible values)
+    ASINStrictValidator (ASIN limiting to currently known patterns)
 """
 import re
 
@@ -42,7 +33,7 @@ class AlphaNumCodeValidatorBase:
     chartype_message = "Only alpha-numeric characters allowed."
     verbose_object_name = "Product Code"
 
-    def validate(self, value):
+    def __call__(self, value):
         """ Validates the given value. """
         self.validate_type(value)
         self.validate_length(value)
@@ -116,9 +107,9 @@ class GTINValidatorBase(AlphaNumCodeValidatorBase):
     """
     chartype_message = "Only numbers allowed."
 
-    def validate(self, value):
+    def __call__(self, value):
         """ Validates the given value. """
-        super().validate(value)
+        super().__call__(value)
         self.valid_checksum(value)
 
     def validate_character_types(self, value):
@@ -168,11 +159,3 @@ EAN13Validator = _EAN13Validator()
 GTIN14Validator = _GTIN14Validator()
 ASINValidator = _ASINValidator()
 ASINStrictValidator = _ASINValidator(strict=True)
-
-
-ISBNValidatorFunc = ISBNValidator.validate
-UPCAValidatorFunc = UPCAValidator.validate
-EAN13ValidatorFunc = EAN13Validator.validate
-GTIN14ValidatorFunc = GTIN14Validator.validate
-ASINValidatorFunc = ASINValidator.validate
-ASINStrictValidatorFunc = ASINStrictValidator.validate

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-gtin-fields',
-    version='0.1.0',
+    version='0.1.1',
     description=str(
         'Provides model fields and validation for GTIN codes '
         '(EAN, UPC, GTIN, ISBN)'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-gtin-fields',
-    version='0.1.1',
+    version='0.1.2',
     description=str(
         'Provides model fields and validation for GTIN codes '
         '(EAN, UPC, GTIN, ISBN)'

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -12,35 +12,35 @@ class ValidatorTestMixin:
 
         self.codes (dict): Should have keys 'valid' and 'invalid', each
             pointing to a list of product codes.
-        self.validator_func (callable): The callable that takes the value to be
+        self.validator (callable): The callable that takes the value to be
             validated.
     """
     def test_validation(self):
         for value in self.codes['invalid']:
             with self.assertRaises(ValidationError):
-                self.validator_func(value)
+                self.validator(value)
 
         for value in self.codes['valid']:
-            self.assertIsNone(self.validator_func(value))
+            self.assertIsNone(self.validator(value))
 
 
 class ISBNValidatorTest(SimpleTestCase, ValidatorTestMixin):
     codes = CODES['ISBN']
-    validator_func = validators.ISBNValidatorFunc
+    validator = validators.ISBNValidator
 
 
 class UPCAValidatorTest(SimpleTestCase, ValidatorTestMixin):
-    validator_func = validators.UPCAValidatorFunc
+    validator = validators.UPCAValidator
     codes = CODES['UPCA']
 
 
 class EAN13ValidatorTest(SimpleTestCase, ValidatorTestMixin):
-    validator_func = validators.EAN13ValidatorFunc
+    validator = validators.EAN13Validator
     codes = CODES['EAN13']
 
 
 class GTIN14ValidatorTest(SimpleTestCase, ValidatorTestMixin):
-    validator_func = validators.GTIN14ValidatorFunc
+    validator = validators.GTIN14Validator
     codes = CODES['GTIN14']
 
 
@@ -50,11 +50,11 @@ class ASINValidatorTest(SimpleTestCase, ValidatorTestMixin):
     This is the 'loose' definition of an ASIN (i.e., Amazon could start
     using any codes within the alpha-numeric range).
     """
-    validator_func = validators.ASINValidatorFunc
+    validator = validators.ASINValidator
     codes = CODES['ASIN']
 
 
 class ASINStrictValidatorTest(SimpleTestCase, ValidatorTestMixin):
     """ The ASINStrictValidator must follow conventional ASIN patterns. """
-    validator_func = validators.ASINStrictValidatorFunc
+    validator = validators.ASINStrictValidator
     codes = CODES['ASIN_strict']


### PR DESCRIPTION
The validators I was using were not serializable, which is a problem since migrations require serializable functions.  The solution is to make my validators callable (so, `__call__` function) and add django's deconstructible decorator.

Semantically, this has the happy side-effect of making the constants much nicer to work with (can just use ISBNValidator instead of ISBNValidatorFunc).